### PR TITLE
Fixed small typo, added Remote Library Examples, and MarketSquare link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@
   - [robotframework-zoomba](https://pypi.org/project/robotframework-zoomba/) Collection of testing libraries spanning GUI, REST/SOAP API, and Windows Desktop automation.
   - [winregistry](https://pypi.org/project/winregistry/) Work with Windows Registry.
 
+- Remote Library Examples
+  - [remote-keyword-library](https://github.com/ThomasJaspers/remote-keyword-library) An example of a Remote Server Keywords library implementation in Java featured in a blog post written by Thomas Jaspers.
+  - [robotframework-scala-remote-library](https://github.com/jg8481/robotframework-scala-remote-library) An example of a Remote Server Keywords library implementation in Scala and based on a blog post written by Thomas Jaspers.
+
 ## Tools
 
 - Built-in tools
@@ -155,7 +159,7 @@
   - [RobotFramework Metrics](https://github.com/adiralashiva8/robotframework-metrics) Dashboard view of execution result with visualization.
 
 - Personal Assistants
-  - [robotframework-test-assistant]](https://github.com/jg8481/leon/tree/develop/packages/robotframework-test-assistant) Use a conversational AI test assistant to control Robot Framework test suites and RPA tasks with your voice or with text commands.
+  - [robotframework-test-assistant](https://github.com/jg8481/leon/tree/develop/packages/robotframework-test-assistant) Use a conversational AI test assistant to control Robot Framework test suites and RPA tasks with your voice or with text commands.
 
 ## Resources
 
@@ -208,6 +212,9 @@
 - Theses
   - [Data-Driven and Keyword-Driven Test Automation Frameworks](http://eliga.fi/Thesis-Pekka-Laukkanen.pdf) Master's Thesis, Pekka Laukkanen
   - [Web  Application  Test  Automation  with  Robot Framework](https://www.theseus.fi/bitstream/handle/10024/93164/Thesis_Jani_Luostarinen_v1_0.pdf?sequence=1) Bachelor's Thesis, Jani Luostarinen
+
+- Shared Code Repositories
+  - [MarketSquare](https://github.com/MarketSquare) A community run collection of repositories for Robot Framework. Originally featured in a RoboCon 2020 lightning talk presented by Edward Manlove.
 
 ## Trainings
 


### PR DESCRIPTION
I fixed a typo I made in a previous PR (sorry about that). I added the MarketSquare (link below) featured in a RoboCon 2020 lightning talk presented by Edward Manlove. I also added a section called Remote Library Examples and added the following to it.

https://github.com/MarketSquare
https://github.com/ThomasJaspers/remote-keyword-library
https://github.com/jg8481/robotframework-scala-remote-library