### PR TITLE
Add robotframework-confluentkafkalibrary

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
   - [robotframework-apachetomcat](https://pypi.org/project/robotframework-apachetomcat/) - Manage Apache Tomcat server.
   - [robotframework-aws](https://pypi.org/project/robotframework-aws/) - Keywords for interacting with AWS services in your test suites.
   - [robotframework-cassandracqllibrary](https://pypi.org/project/robotframework-cassandracqllibrary/) Execute CQL statements in Cassandra Database.
+  - [robotframework-confluentkafkalibrary](https://pypi.org/project/robotframework-confluentkafkalibrary/) Wrapper for the confluent-kafka-python.
   - [robotframework-couchdbaselibrary](https://pypi.org/project/robotframework-couchbaselibrary/) Work with Couchbase.
   - [robotframework-couchbasemanager](https://pypi.org/project/robotframework-couchbasemanager/) Manage Couchbase server.
   - [robotframework-databaselib](https://pypi.org/project/robotframework-databaselib/) Database lib based on SQLAlchemy.


### PR DESCRIPTION
Add robotframework-confluentkafkalibrary to low-level libraries.