### PR TITLE
Add molecule-robotframework Ansible Molecule plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
   - [allure-robotframework](https://pypi.org/project/allure-robotframework/#data) - Robot Framework integration for Allure.
   - [robotframework-rp-tools](https://pypi.org/project/robotframework-rp-tools/) - Listener and visitor modules for integration with ReportPortal.
   - [RobotMK](https://robotmk.org) Robot Framework integration for the Open Source monitoring solution [Checkmk](https://checkmk.com).
+  - [molecule-robotframework](https://pypi.org/project/molecule-robotframework/) - Ansible Molecule plugin for running molecule tests with Robot Framework.
 
 - Verification
   - [Robot Framework Lint](https://github.com/boakley/robotframework-lint) Linter for robot framework plain text files.


### PR DESCRIPTION
Add a project link and short description of the Ansible Molecule plugin
for Robot Framework. This plugin lets Ansible playbook and role
developers use Robot Framework for molecule tests.