### PR TITLE
Add OpenAFS test library

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@
   - [robotframework-xvfb](https://pypi.org/project/robotframework-xvfb/) Interact with Xvfb.
   - [robotframework-zoomba](https://pypi.org/project/robotframework-zoomba/) Collection of testing libraries spanning GUI, REST/SOAP API, and Windows Desktop automation.
   - [winregistry](https://pypi.org/project/winregistry/) Work with Windows Registry.
+  - [robotframework-openafslibrary](https://pypi.org/project/robotframework-openafslibrary/) Test library for the OpenAFS distributed filesystem.
 
 - Remote Library Examples
   - [remote-keyword-library](https://github.com/ThomasJaspers/remote-keyword-library) An example of a Remote Server Keywords library implementation in Java featured in a blog post written by Thomas Jaspers.


### PR DESCRIPTION
Add project link and short description for the OpenAFS Robot Framework
test library.